### PR TITLE
Add support for SharePoint sessions proxied through Microsoft Defender for Cloud Apps (MCAS)

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -659,13 +659,41 @@
     }
 
     try {
-      // Fetch the JSON version first (for generating all previews)
-      const jsonUrl = transcriptUrl.includes('?') 
-        ? `${transcriptUrl}&format=json` 
+      let jsonUrl = transcriptUrl.includes('?')
+        ? `${transcriptUrl}&format=json`
         : `${transcriptUrl}?format=json`;
-      
+
+      // Microsoft Defender for Cloud Apps / MCAS:
+      // SharePoint may return a temporaryDownloadUrl pointing to the
+      // original *.sharepoint.com host, while the authenticated browser
+      // session is running through *.sharepoint.com.mcas.ms.
+      //
+      // Only rewrite the final content request. Do not touch transcript
+      // discovery or metadata URLs.
+      try {
+        const parsedUrl = new URL(jsonUrl);
+
+        if (
+          window.location.hostname.endsWith('.sharepoint.com.mcas.ms') &&
+          parsedUrl.hostname.endsWith('.sharepoint.com')
+        ) {
+          parsedUrl.hostname = `${parsedUrl.hostname}.mcas.ms`;
+          jsonUrl = parsedUrl.href;
+
+          console.debug(
+            '[Transcript Downloader] Rewriting transcript URL through MCAS:',
+            jsonUrl
+          );
+        }
+      } catch (e) {
+        console.warn(
+          '[Transcript Downloader] Failed to rewrite transcript URL:',
+          e
+        );
+      }
+
       console.debug('[Transcript Downloader] Fetching JSON from:', jsonUrl);
-      
+
       const jsonResponse = await fetch(jsonUrl);
       if (!jsonResponse.ok) {
         throw new Error(`HTTP ${jsonResponse.status}: ${jsonResponse.statusText}`);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,15 +11,19 @@
   ],
   "host_permissions": [
     "https://*.sharepoint.com/*",
+    "https://*.sharepoint.com.mcas.ms/*",
     "https://teams.microsoft.com/*",
-    "https://teams.cloud.microsoft/*"
+    "https://teams.cloud.microsoft/*",
+    "https://teams.microsoft.com.mcas.ms/*"
   ],
   "content_scripts": [
     {
       "matches": [
         "https://*.sharepoint.com/*",
+        "https://*.sharepoint.com.mcas.ms/*",
         "https://teams.microsoft.com/*",
-        "https://teams.cloud.microsoft/*"
+        "https://teams.cloud.microsoft/*",
+        "https://teams.microsoft.com.mcas.ms/*"
       ],
       "js": ["intercept.js"],
       "run_at": "document_start",
@@ -29,8 +33,10 @@
     {
       "matches": [
         "https://*.sharepoint.com/*",
+        "https://*.sharepoint.com.mcas.ms/*",
         "https://teams.microsoft.com/*",
-        "https://teams.cloud.microsoft/*"
+        "https://teams.cloud.microsoft/*",
+        "https://teams.microsoft.com.mcas.ms/*"
       ],
       "js": ["content.js"],
       "css": ["modal.css"],
@@ -51,8 +57,10 @@
       "resources": ["intercept.js", "mux-worker.js"],
       "matches": [
         "https://*.sharepoint.com/*",
+        "https://*.sharepoint.com.mcas.ms/*",
         "https://teams.microsoft.com/*",
-        "https://teams.cloud.microsoft/*"
+        "https://teams.cloud.microsoft/*",
+        "https://teams.microsoft.com.mcas.ms/*"
       ]
     }
   ]


### PR DESCRIPTION
This PR adds support for SharePoint environments where Microsoft Defender for Cloud Apps / Conditional Access App Control proxies SharePoint through `*.sharepoint.com.mcas.ms`.

In these environments, the extension was not working for two separate reasons:

1. The extension manifest only matched `*.sharepoint.com`, so the content scripts were not injected when SharePoint was accessed through `*.sharepoint.com.mcas.ms`.
2. SharePoint transcript metadata can still return a `temporaryDownloadUrl` pointing to the original `*.sharepoint.com` host. When the authenticated browser session is running through MCAS, fetching that URL directly results in `HTTP 401 Unauthenticated`.

For example:

```text
Page origin:
https://tenant-my.sharepoint.com.mcas.ms

temporaryDownloadUrl:
https://tenant-my.sharepoint.com/.../media/transcripts/.../content
```

The direct request to `tenant-my.sharepoint.com` is unauthenticated, while the equivalent URL routed through:

```text
https://tenant-my.sharepoint.com.mcas.ms/...
```

works correctly with the existing authenticated MCAS session.

### Changes

- Add `https://*.sharepoint.com.mcas.ms/*` to:
  - `host_permissions`
  - both `content_scripts.matches`
  - `web_accessible_resources.matches`

- When downloading transcript content, detect whether the current SharePoint page is running through MCAS.

- If the returned transcript URL points to a normal `*.sharepoint.com` host while the current page is on `*.sharepoint.com.mcas.ms`, rewrite only the final transcript content request to append `.mcas.ms` to the SharePoint hostname.

The transcript discovery and metadata logic remain unchanged. The URL rewrite is intentionally applied only to the final transcript content fetch in order to avoid affecting the existing SharePoint/Teams detection flow.

Normal non-MCAS SharePoint environments are unaffected by this change.

Tested with Firefox against a SharePoint tenant protected by Microsoft Defender for Cloud Apps, where transcript downloads previously failed with:

```text
Error downloading transcript: HTTP 401
```

After routing the transcript content URL through the existing MCAS hostname, the JSON transcript downloads successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for downloading transcripts from Microsoft Defender for Cloud Apps-protected SharePoint pages.
  * Extended compatibility to protected SharePoint and Teams domains.

* **Bug Fixes**
  * Improved transcript content requests when accessed through protected cloud application URLs.
  * Added graceful handling when protected URL conversion fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->